### PR TITLE
Add mos6502.lib build for GBDK installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ PKG = gbdk
 # Version, used for tarballs & docs
 VER = 4.0.6
 
-PORTS=sm83 z80
+PORTS=sm83 z80 mos6502
 PLATFORMS=gb ap duck gg sms msxdos
 
 # Prefix to add to the standard tools.  Usefull for a standard gcc
@@ -262,7 +262,7 @@ gbdk-dist-examples-clean:
 
 
 # Copy SDDC executable files
-SDCC_BINS = makebin packihx sdar sdasgb sdcc sdcdb sdcpp sdldgb sdnm sdobjcopy sdranlib sz80 sdasz80 sdldz80
+SDCC_BINS = makebin packihx sdar sdasgb sdcc sdcdb sdcpp sdldgb sdnm sdobjcopy sdranlib sz80 sdasz80 sdldz80 sdas6500 sdld
 ifeq ($(OS),Windows_NT)
 MINGW64_RUNTIME = \
 	libgcc_s_seh-1.dll \

--- a/gbdk-lib/Makefile.common
+++ b/gbdk-lib/Makefile.common
@@ -8,7 +8,7 @@ MODEL =	small
 endif
 
 ifndef PORTS
-PORTS = sm83 z80
+PORTS = sm83 z80 mos6502
 endif
 ifndef PLATFORMS
 PLATFORMS = gb ap duck gg sms msxdos
@@ -25,6 +25,7 @@ SDAR = 	$(subst \,/,'$(SDCCLIB)')/bin/sdar
 
 AS_Z80 = $(SDCCLIB)/bin/sdasz80
 AS_SM83 = $(SDCCLIB)/bin/sdasgb
+AS_6500 = $(SDCCLIB)/bin/sdas6500
 
 CLEANSPEC = *.o *.cdb *.sym *.lst *~ *.asm
 

--- a/gbdk-lib/include/asm/mos6502/provides.h
+++ b/gbdk-lib/include/asm/mos6502/provides.h
@@ -1,0 +1,4 @@
+#define USE_C_MEMCPY	0
+#define USE_C_STRCPY	0
+#define USE_C_STRCMP	1
+

--- a/gbdk-lib/include/asm/mos6502/stdarg.h
+++ b/gbdk-lib/include/asm/mos6502/stdarg.h
@@ -1,0 +1,18 @@
+#ifndef ASM_MOS6502_STDARG_INCLUDE
+#define ASM_MOS6502_STDARG_INCLUDE
+
+/* sdcc pushes right to left with the real sizes, not cast up
+   to an int.
+   so printf(int, char, long)
+   results in push long, push char, push int
+   On the 6502 the stack grows down, so the things seem to be in
+   the correct order.
+ */
+
+typedef unsigned char * va_list;
+#define va_start(list, last)	list = (unsigned char *)&last + sizeof(last)
+#define va_arg(list, type)	*((type *)((list += sizeof(type)) - sizeof(type)))
+
+#define va_end(list)
+
+#endif

--- a/gbdk-lib/include/asm/mos6502/string.h
+++ b/gbdk-lib/include/asm/mos6502/string.h
@@ -1,0 +1,144 @@
+/** @file string.h
+    Generic string functions.
+ */
+#ifndef STRING_INCLUDE
+#define STRING_INCLUDE
+
+#include <types.h>
+
+/** Copies the string pointed to by __src__ (including the terminating
+    `\0' character) to the array pointed to by __dest__.
+
+    The strings may not overlap, and the destination string dest must
+    be large enough to receive the copy.
+
+    @param dest			Array to copy into
+    @param src			Array to copy from
+
+    @return 			A pointer to dest
+*/
+char *strcpy(char *dest, const char *src) OLDCALL;
+
+/** Compares strings
+
+    @param s1         First string to compare
+    @param s2         Second string to compare
+
+    Returns:
+    \li > 0 if __s1__ > __s2__
+    \li 0 if __s1__ == __s2__
+    \li < 0 if __s1__ < __s2__
+*/
+int strcmp(const char *s1, const char *s2);
+
+/** Copies n bytes from memory area src to memory area dest.
+
+    The memory areas may not overlap.
+
+    @param dest			Buffer to copy into
+    @param src			Buffer to copy from
+    @param len			Number of Bytes to copy
+*/
+void *memcpy(void *dest, const void *src, size_t len);
+
+/** Copies n bytes from memory area src to memory area dest, areas may overlap
+ */
+void *memmove (void *dest, const void *src, size_t n) OLDCALL;
+
+/** Fills the memory region __s__ with __n__ bytes using value __c__
+
+    @param s         Buffer to fill
+    @param c         char value to fill with (truncated from int)
+    @param n         Number of bytes to fill
+*/
+void *memset (void *s, int c, size_t n);
+
+/** Reverses the characters in a string
+
+    @param s         Pointer to string to reverse.
+
+    For example 'abcdefg' will become 'gfedcba'.
+
+    Banked as the string must be modifiable.
+
+    Returns: Pointer to __s__
+*/
+char *reverse(char *s) NONBANKED;
+
+/** Concatenate Strings. Appends string __s2__ to the end of string __s1__
+
+    @param s1         String to append onto
+    @param s2         String to copy from
+
+    For example 'abc' and 'def' will become 'abcdef'.
+
+    String __s1__ must be large enough to store both __s1__ and __s2__.
+
+    Returns: Pointer to __s1__
+*/
+char *strcat(char *s1, const char *s2) NONBANKED;
+
+/** Calculates the length of a string
+
+    @param s         String to calculate length of
+
+    Returns: Length of string not including the terminating `\0' character.
+*/
+int strlen(const char *s) OLDCALL;
+
+/**Concatenate at most __n__ characters from string __s2__ onto the end of __s1__.
+
+    @param s1         String to append onto
+    @param s2         String to copy from
+    @param n          Max number of characters to copy from __s2__
+
+    String __s1__ must be large enough to store both __s1__ and __n__ characters of __s2__
+
+    Returns: Pointer to __s1__
+*/
+char *strncat(char *s1, const char *s2, int n) NONBANKED;
+
+/** Compare strings (at most n characters):
+
+    @param s1         First string to compare
+    @param s2         Second string to compare
+    @param n          Max number of characters to compare
+
+    Returns:
+    \li > 0 if __s1__ > __s2__
+    \li 0 if __s1__ == __s2__
+    \li < 0 if __s1__ < __s2__
+*/
+int strncmp(const char *s1, const char *s2, int n) NONBANKED;
+
+/** Copy __n__ characters from string __s2__ to __s1__
+
+
+    @param s1         String to copy into
+    @param s2         String to copy from
+    @param n          Max number of characters to copy from __s2__
+
+    If __s2__ is shorter than __n__, the remaining
+    bytes in __s1__ are filled with \0.
+
+    Warning: If there is no \0 in the first __n__ bytes of __s2__ then __s1__
+    will not be null terminated.
+
+    Returns: Pointer to __s1__
+*/
+char *strncpy(char *s1, const char *s2, int n) NONBANKED;
+
+/** Compares buffers
+
+    @param buf1         First buffer to compare
+    @param buf2         Second buffer to compare
+    @param count        Buffer length
+
+    Returns:
+    \li > 0 if __buf1__ > __buf2__
+    \li 0 if __buf1__ == __buf2__
+    \li < 0 if __buf1__ < __buf2__
+*/
+int memcmp(const void *buf1, const void *buf2, size_t count);
+
+#endif

--- a/gbdk-lib/include/asm/mos6502/types.h
+++ b/gbdk-lib/include/asm/mos6502/types.h
@@ -1,22 +1,19 @@
-/** @file asm/z80/types.h
-    @anchor file_asm_z80_types_h
+/** @file asm/mos6502/types.h
+    @anchor file_asm_mos6502_types_h
     Types definitions for the gb.
 */
-#ifndef ASM_Z80_TYPES_INCLUDE
-#define ASM_Z80_TYPES_INCLUDE
+#ifndef ASM_MOS6502_TYPES_INCLUDE
+#define ASM_MOS6502_TYPES_INCLUDE
 
-#ifndef __PORT_z80
-  #error z80 only.
+#ifndef __PORT_mos6502
+  #error mos6502 only.
 #endif
 
 #ifdef __SDCC
 
-#define Z88DK_CALLEE __sdcccall(0) __z88dk_callee
-#define Z88DK_FASTCALL __z88dk_fastcall
-
-#define NONBANKED       __nonbanked /**< Placed in the non-banked lower 16K region (bank 0), regardless of the bank selected by it's source file. */
-#define BANKED          __banked /**< The function will use banked sdcc calls, and is placed in the bank selected by it's source file (or compiler switches). */
-#define REENTRANT                /**< Needed for mos6502 target when functions take too many parameters. */
+#define NONBANKED	            /**< Currently a no-op for mos6502 target. */
+#define BANKED		            /**< Currently a no-op for mos6502 target. */
+#define REENTRANT	__reentrant /**< Needed for mos6502 target when functions take too many parameters. */
 
 /**  Use to create a block of of code which should execute with interrupts temporarily turned off.
 
@@ -27,7 +24,7 @@
 
     @see enable_interrupts, disable_interrupts
 */
-#define CRITICAL        __critical
+#define CRITICAL		__critical
 
 /**  Indicate to the compiler the function will be used as an interrupt handler.
 
@@ -35,13 +32,10 @@
     function added via add_VBL() (or LCD, etc). The attributes
     are only required when constructing a bare jump from the
     interrupt vector itself.
+
+    @see ISR_VECTOR(), ISR_NESTED_VECTOR()
 */
-#define INTERRUPT       __interrupt
-
-#else
-
-#define Z88DK_CALLEE
-#define Z88DK_FASTCALL
+#define INTERRUPT		__interrupt
 
 #endif
 

--- a/gbdk-lib/include/asm/sm83/types.h
+++ b/gbdk-lib/include/asm/sm83/types.h
@@ -13,6 +13,7 @@
 
 #define NONBANKED		__nonbanked  /**< Placed in the non-banked lower 16K region (bank 0), regardless of the bank selected by it's source file. */
 #define BANKED			__banked     /**< The function will use banked sdcc calls, and is placed in the bank selected by it's source file (or compiler switches). */
+#define REENTRANT		             /**< Needed for mos6502 target when functions take too many parameters. */
 
 /**  Use to create a block of of code which should execute with interrupts temporarily turned off.
 

--- a/gbdk-lib/include/asm/types.h
+++ b/gbdk-lib/include/asm/types.h
@@ -8,6 +8,8 @@
 #include <asm/sm83/types.h>
 #elif defined(__PORT_z80)
 #include <asm/z80/types.h>
+#elif defined(__PORT_mos6502)
+#include <asm/mos6502/types.h>
 #else
 #error Unrecognised port
 #endif

--- a/gbdk-lib/include/gbdk/gbdk-lib.h
+++ b/gbdk-lib/include/gbdk/gbdk-lib.h
@@ -8,6 +8,8 @@
   #include <asm/sm83/provides.h>
 #elif defined(__PORT_z80)
   #include <asm/z80/provides.h>
+#elif defined(__PORT_mos6502)
+  #include <asm/mos6502/provides.h>
 #else
   #error Unrecognized port
 #endif

--- a/gbdk-lib/include/stdarg.h
+++ b/gbdk-lib/include/stdarg.h
@@ -5,8 +5,8 @@
 #include <asm/sm83/stdarg.h>
 #elif defined(__PORT_z80)
 #include <asm/z80/stdarg.h>
-#else
-#error Unrecognised port.
+#elif defined(__PORT_mos6502)
+#include <asm/mos6502/stdarg.h>
 #endif
 
 #endif

--- a/gbdk-lib/include/stdatomic.h
+++ b/gbdk-lib/include/stdatomic.h
@@ -5,7 +5,7 @@
 
 typedef struct {unsigned char flag;} atomic_flag;
 
-#if defined(__SDCC_z80) || defined(__SDCC_z180) || defined(__SDCC_ez80_z80) || defined(__SDCC_sm83) || defined(__SDCC_r2k) || defined(__SDCC_r3ka) || defined(__SDCC_stm8) || defined(__SDCC_hc08) || defined(__SDCC_s08)
+#if defined(__SDCC_z80) || defined(__SDCC_z180) || defined(__SDCC_ez80_z80) || defined(__SDCC_sm83) || defined(__SDCC_r2k) || defined(__SDCC_r3ka) || defined(__SDCC_stm8) || defined(__SDCC_hc08) || defined(__SDCC_s08) || defined(__SDCC_mos6502)
 #define ATOMIC_FLAG_INIT {1}
 //#elif defined(__SDCC_mcs51)
 //#define ATOMIC_FLAG_INIT {0}

--- a/gbdk-lib/include/stdio.h
+++ b/gbdk-lib/include/stdio.h
@@ -37,7 +37,7 @@ void putchar(char c) OLDCALL;
     be explicitly re-cast as such when calling the function.
     See @ref docs_chars_varargs for more details.
  */
-void printf(const char *format, ...) OLDCALL;
+void printf(const char *format, ...) OLDCALL REENTRANT;
 
 /** Print the string and arguments given by format to a buffer.
 
@@ -46,7 +46,7 @@ void printf(const char *format, ...) OLDCALL;
 
     Does not return the number of characters printed.
  */
-void sprintf(char *str, const char *format, ...) OLDCALL;
+void sprintf(char *str, const char *format, ...) OLDCALL REENTRANT;
 
 /** puts() writes the string __s__ and a trailing newline to stdout.
 */

--- a/gbdk-lib/include/stdlib.h
+++ b/gbdk-lib/include/stdlib.h
@@ -6,7 +6,7 @@
 
 #include <types.h>
 
-#if !defined(__SDCC_mcs51) && !defined(__SDCC_ds390) && !defined(__SDCC_ds400) && !defined(__SDCC_hc08) && !defined(__SDCC_s08) && !defined(__SDCC_pic14) && !defined(__SDCC_pic16) && !defined(__SDCC_pdk13) && !defined(__SDCC_pdk14) && !defined(__SDCC_pdk15)
+#if !defined(__SDCC_mcs51) && !defined(__SDCC_ds390) && !defined(__SDCC_ds400) && !defined(__SDCC_hc08) && !defined(__SDCC_s08) && !defined(__SDCC_mos6502) && !defined(__SDCC_mos65c02) && !defined(__SDCC_pic14) && !defined(__SDCC_pic16) && !defined(__SDCC_pdk13) && !defined(__SDCC_pdk14) && !defined(__SDCC_pdk15)
 #define __reentrant
 #endif
 

--- a/gbdk-lib/include/string.h
+++ b/gbdk-lib/include/string.h
@@ -4,14 +4,14 @@
 #ifndef STD_STRING_INCLUDE
 #define STD_STRING_INCLUDE
 
-#ifdef __PORT_sm83
+#if defined(__PORT_sm83)
   #include <asm/sm83/string.h>
+#elif defined(__PORT_z80)
+  #include <asm/z80/string.h>
+#elif defined(__PORT_mos6502)
+  #include <asm/mos6502/string.h>
 #else
-  #ifdef __PORT_z80
-    #include <asm/z80/string.h>
-  #else
-    #error Unrecognised port
-  #endif
+  #error Unrecognized port
 #endif
 
 #endif

--- a/gbdk-lib/libc/Makefile
+++ b/gbdk-lib/libc/Makefile
@@ -3,7 +3,7 @@
 .EXPORT_ALL_VARIABLES:
 
 ifeq ($(PORTS),)
-	PORTS = sm83 z80
+	PORTS = sm83 z80 mos6502
 endif
 
 ifeq ($(PLATFORMS),)

--- a/gbdk-lib/libc/_divulong.c
+++ b/gbdk-lib/libc/_divulong.c
@@ -322,7 +322,7 @@ _divulong (unsigned long a, unsigned long b)
 {
   unsigned long reste = 0L;
   unsigned char count = 32;
-  #if defined(__SDCC_STACK_AUTO) || defined(__SDCC_z80) || defined(__SDCC_sm83)
+  #if defined(__SDCC_STACK_AUTO) || defined(__SDCC_z80) || defined(__SDCC_sm83) || defined(__SDCC_mos6502)
     char c;
   #else
     bit c;

--- a/gbdk-lib/libc/asm/mos6502/Makefile
+++ b/gbdk-lib/libc/asm/mos6502/Makefile
@@ -1,0 +1,23 @@
+# sm83 specific Makefile
+
+TOPDIR = ../../..
+
+THIS = mos6502
+
+ASSRC = __sdcc_indirect_jsr.s _memcpy.s _strcpy.s _strcmp.s \
+	_divuint.s _divsint.s _modsint.s _moduint.s \
+	_divulong.s _divslong.s _modulong.s _modslong.s \
+	_mulint.s \
+	_muluchar.s _mulschar.s
+
+CSRC =	_memmove.c _memset.c _ret.c abs.c \
+	_rrulonglong.c _rrslonglong.c \
+	atomic_flag_test_and_set.c
+
+include $(TOPDIR)/Makefile.common
+
+AS = $(AS_6500)
+
+include ../Makefile.port
+
+

--- a/gbdk-lib/libc/asm/mos6502/__memcpy.s
+++ b/gbdk-lib/libc/asm/mos6502/__memcpy.s
@@ -1,0 +1,95 @@
+;-------------------------------------------------------------------------
+;   memcpy.s - standarc C library
+;
+;   Copyright (C) 2003, Ullrich von Bassewitz
+;   Copyright (C) 2009, Christian Krueger
+;   Copyright (C) 2022, Gabriele Gorla
+;
+;   This library is free software; you can redistribute it and/or modify it
+;   under the terms of the GNU General Public License as published by the
+;   Free Software Foundation; either version 2, or (at your option) any
+;   later version.
+;
+;   This library is distributed in the hope that it will be useful,
+;   but WITHOUT ANY WARRANTY; without even the implied warranty of
+;   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;   GNU General Public License for more details.
+;
+;   You should have received a copy of the GNU General Public License
+;   along with this library; see the file COPYING. If not, write to the
+;   Free Software Foundation, 51 Franklin Street, Fifth Floor, Boston,
+;   MA 02110-1301, USA.
+;
+;   As a special exception, if you link this library with other files,
+;   some of which are compiled with SDCC, to produce an executable,
+;   this library does not by itself cause the resulting executable to
+;   be covered by the GNU General Public License. This exception does
+;   not however invalidate any other reasons why the executable file
+;   might be covered by the GNU General Public License.
+;-------------------------------------------------------------------------
+
+	.module ___memcpy
+
+;--------------------------------------------------------
+; exported symbols
+;--------------------------------------------------------
+	.globl ___memcpy_PARM_2
+	.globl ___memcpy_PARM_3
+	.globl ___memcpy
+
+;--------------------------------------------------------
+; overlayable function paramters in zero page
+;--------------------------------------------------------
+	.area	OSEG    (PAG, OVR)
+___memcpy_PARM_2:
+	.ds 2
+___memcpy_PARM_3:
+	.ds 2
+
+;--------------------------------------------------------
+; local aliases
+;--------------------------------------------------------
+	.define save  "___SDCC_m6502_ret0"
+	.define dst   "___SDCC_m6502_ret2"
+	.define src   "___memcpy_PARM_2"
+	.define count "___memcpy_PARM_3"
+	
+;--------------------------------------------------------
+; code
+;--------------------------------------------------------
+	.area CODE
+
+___memcpy:
+	sta	*save+0
+	stx	*save+1
+	sta	*dst+0
+	stx	*dst+1
+
+	ldy	#0
+	ldx	*count+1
+	beq	L2
+L1:
+	lda	[*src],y
+	sta	[*dst],y
+	iny
+	lda	[*src],y
+	sta	[*dst],y
+	iny
+	bne	L1
+	inc	*src+1
+	inc	*dst+1
+	dex
+	bne	L1
+L2:
+	ldx	*count+0
+	beq	done
+L3:
+	lda	[*src],y
+	sta	[*dst],y
+	iny
+	dex
+	bne	L3
+done:
+	lda	*save+0
+	ldx	*save+1
+	rts

--- a/gbdk-lib/libc/asm/mos6502/__sdcc_indirect_jsr.s
+++ b/gbdk-lib/libc/asm/mos6502/__sdcc_indirect_jsr.s
@@ -1,0 +1,3 @@
+.area CODE
+__sdcc_indirect_jsr::
+	jmp	[__TEMP]

--- a/gbdk-lib/libc/asm/mos6502/_divsint.s
+++ b/gbdk-lib/libc/asm/mos6502/_divsint.s
@@ -1,0 +1,83 @@
+;-------------------------------------------------------------------------
+;   _divsint.s - routine for division of 16 bit signed int
+;
+;   Copyright (C) 1998, Ullrich von Bassewitz
+;   Copyright (C) 2022, Gabriele Gorla
+;
+;   This library is free software; you can redistribute it and/or modify it
+;   under the terms of the GNU General Public License as published by the
+;   Free Software Foundation; either version 2, or (at your option) any
+;   later version.
+;
+;   This library is distributed in the hope that it will be useful,
+;   but WITHOUT ANY WARRANTY; without even the implied warranty of
+;   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;   GNU General Public License for more details.
+;
+;   You should have received a copy of the GNU General Public License
+;   along with this library; see the file COPYING. If not, write to the
+;   Free Software Foundation, 51 Franklin Street, Fifth Floor, Boston,
+;   MA 02110-1301, USA.
+;
+;   As a special exception, if you link this library with other files,
+;   some of which are compiled with SDCC, to produce an executable,
+;   this library does not by itself cause the resulting executable to
+;   be covered by the GNU General Public License. This exception does
+;   not however invalidate any other reasons why the executable file
+;   might be covered by the GNU General Public License.
+;-------------------------------------------------------------------------
+
+	.module _divsint
+
+;--------------------------------------------------------
+; exported symbols
+;--------------------------------------------------------
+	.globl __divsint
+	.globl ___sdivmod16
+
+;--------------------------------------------------------
+; local aliases
+;--------------------------------------------------------
+	.define res "___SDCC_m6502_ret0"
+	.define den "__divsint_PARM_2"
+	.define rem "___SDCC_m6502_ret2"
+	.define s1  "___SDCC_m6502_ret4"
+	.define s2  "___SDCC_m6502_ret5"
+
+;--------------------------------------------------------
+; code
+;--------------------------------------------------------
+	.area CODE
+
+__divsint:
+	jsr	___sdivmod16
+	lda	*res+0
+	ldx	*res+1
+	pha
+	lda	*s1
+	eor	*s2
+	bpl	pos
+	pla
+	jmp 	___negax
+pos:
+	pla
+	rts
+
+___sdivmod16:
+	stx	*s1
+	jsr	_abs
+	pha
+	lda     *__divsint_PARM_2+1
+	sta	*s2
+	bpl	skip
+	sec
+	lda	#0x00
+	sbc	*__divsint_PARM_2+0
+        sta     *__divsint_PARM_2+0
+	lda	#0x00
+	sbc	*__divsint_PARM_2+1
+        sta     *__divsint_PARM_2+1
+skip:
+	pla
+	jmp 	___udivmod16
+

--- a/gbdk-lib/libc/asm/mos6502/_divslong.s
+++ b/gbdk-lib/libc/asm/mos6502/_divslong.s
@@ -1,0 +1,106 @@
+;-------------------------------------------------------------------------
+;   _divslong.s - routine for 32 bit signed long division
+;
+;   Copyright (C) 1998, Ullrich von Bassewitz
+;   Copyright (C) 2022, Gabriele Gorla
+;
+;   This library is free software; you can redistribute it and/or modify it
+;   under the terms of the GNU General Public License as published by the
+;   Free Software Foundation; either version 2, or (at your option) any
+;   later version.
+;
+;   This library is distributed in the hope that it will be useful,
+;   but WITHOUT ANY WARRANTY; without even the implied warranty of
+;   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;   GNU General Public License for more details.
+;
+;   You should have received a copy of the GNU General Public License
+;   along with this library; see the file COPYING. If not, write to the
+;   Free Software Foundation, 51 Franklin Street, Fifth Floor, Boston,
+;   MA 02110-1301, USA.
+;
+;   As a special exception, if you link this library with other files,
+;   some of which are compiled with SDCC, to produce an executable,
+;   this library does not by itself cause the resulting executable to
+;   be covered by the GNU General Public License. This exception does
+;   not however invalidate any other reasons why the executable file
+;   might be covered by the GNU General Public License.
+;-------------------------------------------------------------------------
+
+	.module _divslong
+
+;--------------------------------------------------------
+; exported symbols
+;--------------------------------------------------------
+	.globl __divslong
+	.globl ___sdivmod32
+
+;--------------------------------------------------------
+; local aliases
+;--------------------------------------------------------
+	.define res0 "__divslong_PARM_1+0"
+	.define res1 "__divslong_PARM_1+1"
+	.define res2 "___SDCC_m6502_ret2"
+	.define res3 "___SDCC_m6502_ret3"
+	.define den  "__divslong_PARM_2"
+	.define rem  "___SDCC_m6502_ret4"
+	.define s1   "___SDCC_m6502_ret0"
+	.define s2   "___SDCC_m6502_ret1"
+
+;--------------------------------------------------------
+; code
+;--------------------------------------------------------
+	.area CODE
+__divslong:
+	jsr	___sdivmod32
+	lda	*s1
+	eor	*s2
+	bpl	pos
+; neg res
+	sec
+	lda	#0x00
+	sbc	*res0
+	tay
+	lda	#0x00
+	sbc	*res1
+	tax
+	lda	#0x00
+	sbc	*res2
+	sta	*res2
+	lda	#0x00
+	sbc	*res3
+	sta	*res3
+	tya
+	rts
+pos:
+	lda	*res0
+	ldx	*res1
+	rts
+
+___sdivmod32:
+	lda	*__divslong_PARM_1+3
+	sta	*s1
+	bpl 	pos1
+	ldy	#0
+	jsr	___neg_div32_param
+pos1:
+	lda	*__divslong_PARM_2+3
+	sta	*s2
+	bpl 	pos2
+	ldy	#4
+	jsr	___neg_div32_param
+pos2:
+	jmp 	___udivmod32
+
+___neg_div32_param:
+	sec
+	ldx	#0x04
+loop:
+	lda	#0x00
+	sbc	*__divslong_PARM_1+0,y
+	sta	*__divslong_PARM_1+0,y
+	iny
+	dex
+	bne loop
+	rts
+

--- a/gbdk-lib/libc/asm/mos6502/_divuint.s
+++ b/gbdk-lib/libc/asm/mos6502/_divuint.s
@@ -1,0 +1,123 @@
+;-------------------------------------------------------------------------
+;   _divuint.s - routine for division of 16 bit unsigned int
+;
+;   Copyright (C) 1998, Ullrich von Bassewitz
+;   Copyright (C) 2022, Gabriele Gorla
+;
+;   This library is free software; you can redistribute it and/or modify it
+;   under the terms of the GNU General Public License as published by the
+;   Free Software Foundation; either version 2, or (at your option) any
+;   later version.
+;
+;   This library is distributed in the hope that it will be useful,
+;   but WITHOUT ANY WARRANTY; without even the implied warranty of
+;   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;   GNU General Public License for more details.
+;
+;   You should have received a copy of the GNU General Public License
+;   along with this library; see the file COPYING. If not, write to the
+;   Free Software Foundation, 51 Franklin Street, Fifth Floor, Boston,
+;   MA 02110-1301, USA.
+;
+;   As a special exception, if you link this library with other files,
+;   some of which are compiled with SDCC, to produce an executable,
+;   this library does not by itself cause the resulting executable to
+;   be covered by the GNU General Public License. This exception does
+;   not however invalidate any other reasons why the executable file
+;   might be covered by the GNU General Public License.
+;-------------------------------------------------------------------------
+
+	.module _divuint
+
+;--------------------------------------------------------
+; exported symbols
+;--------------------------------------------------------
+	.globl __divuint_PARM_2
+	.globl __divsint_PARM_2
+	.globl __moduint_PARM_2
+	.globl __modsint_PARM_2
+	.globl __divuint
+	.globl ___udivmod16
+
+;--------------------------------------------------------
+; overlayable function paramters in zero page
+;--------------------------------------------------------
+	.area	OSEG    (PAG, OVR)
+__divuint_PARM_2:
+__divsint_PARM_2:
+__moduint_PARM_2:
+__modsint_PARM_2:
+	.ds 2
+
+;--------------------------------------------------------
+; local aliases
+;--------------------------------------------------------
+	.define res "___SDCC_m6502_ret0"
+	.define den "__divuint_PARM_2"
+	.define rem "___SDCC_m6502_ret2"
+	.define s1  "___SDCC_m6502_ret4"
+	.define s2  "___SDCC_m6502_ret5"
+
+;--------------------------------------------------------
+; code
+;--------------------------------------------------------
+	.area CODE
+
+__divuint:
+	jsr	___udivmod16
+	lda	*res+0
+	ldx	*res+1
+	rts
+
+___udivmod16:
+	sta	*res+0
+	stx	*res+1
+
+	lda	#0
+	sta	*rem+1
+	ldy	#16
+;	ldx	__divuint_PARM_2+1
+;	beq	div16x8
+next_bit:
+	asl	*res+0
+	rol	*res+1
+	rol	a
+	rol	*rem+1
+
+	tax
+	cmp	*den+0
+	lda	*rem+1
+	sbc	*den+1
+	bcc	L1
+	sta	*rem+1
+	txa
+	sbc	*den+0
+	tax
+	inc	*res+0
+L1:
+	txa
+	dey
+	bne	next_bit
+	sta	*rem+0
+	rts
+
+;div16x8:
+;LL0:
+;	asl	*___SDCC_m6502_ret0+0
+;	rol	*___SDCC_m6502_ret0+1
+;	rol	a
+;	bcs	LL1
+;	cmp	__divuint_PARM_2+0
+;	bcc	LL2
+;LL1:
+;	sbc	__divuint_PARM_2+0
+;	inc	*___SDCC_m6502_ret0+0
+;LL2:
+;	dey
+;	bne	LL0
+;	sta	*___SDCC_m6502_ret2+0
+;
+;	lda	*___SDCC_m6502_ret0+0
+;	ldx	*___SDCC_m6502_ret0+1
+;	rts
+

--- a/gbdk-lib/libc/asm/mos6502/_divulong.s
+++ b/gbdk-lib/libc/asm/mos6502/_divulong.s
@@ -1,0 +1,136 @@
+;-------------------------------------------------------------------------
+;   _divulong.s - routine for 32 bit unsigned long division
+;
+;   Copyright (C) 1998, Ullrich von Bassewitz
+;   Copyright (C) 2022, Gabriele Gorla
+;
+;   This library is free software; you can redistribute it and/or modify it
+;   under the terms of the GNU General Public License as published by the
+;   Free Software Foundation; either version 2, or (at your option) any
+;   later version.
+;
+;   This library is distributed in the hope that it will be useful,
+;   but WITHOUT ANY WARRANTY; without even the implied warranty of
+;   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;   GNU General Public License for more details.
+;
+;   You should have received a copy of the GNU General Public License
+;   along with this library; see the file COPYING. If not, write to the
+;   Free Software Foundation, 51 Franklin Street, Fifth Floor, Boston,
+;   MA 02110-1301, USA.
+;
+;   As a special exception, if you link this library with other files,
+;   some of which are compiled with SDCC, to produce an executable,
+;   this library does not by itself cause the resulting executable to
+;   be covered by the GNU General Public License. This exception does
+;   not however invalidate any other reasons why the executable file
+;   might be covered by the GNU General Public License.
+;-------------------------------------------------------------------------
+
+	.module _divulong
+
+;--------------------------------------------------------
+; exported symbols
+;--------------------------------------------------------
+	.globl __divulong_PARM_2
+	.globl __divulong_PARM_1
+	.globl __divslong_PARM_2
+	.globl __divslong_PARM_1
+	.globl __modulong_PARM_2
+	.globl __modulong_PARM_1
+	.globl __modslong_PARM_2
+	.globl __modslong_PARM_1
+	.globl __divulong
+	.globl ___udivmod32
+
+;--------------------------------------------------------
+; overlayable function paramters in zero page
+;--------------------------------------------------------
+	.area	OSEG    (PAG, OVR)
+__divulong_PARM_1:
+__divslong_PARM_1:
+__modulong_PARM_1:
+__modslong_PARM_1:
+	.ds 4
+__divulong_PARM_2:
+__divslong_PARM_2:
+__modulong_PARM_2:
+__modslong_PARM_2:
+	.ds 4
+
+;--------------------------------------------------------
+; local aliases
+;--------------------------------------------------------
+	.define res0 "__divulong_PARM_1+0"
+	.define res1 "__divulong_PARM_1+1"
+	.define res2 "___SDCC_m6502_ret2"
+	.define res3 "___SDCC_m6502_ret3"
+	.define den  "__divulong_PARM_2"
+	.define rem  "___SDCC_m6502_ret4"
+	.define s1  "___SDCC_m6502_ret0"
+	.define s2  "___SDCC_m6502_ret1"
+	
+;--------------------------------------------------------
+; code
+;--------------------------------------------------------
+	.area CODE
+
+__divulong:
+	jsr	___udivmod32
+	lda	*res0
+	ldx	*res1
+	rts
+
+___udivmod32:
+        ldx	__divulong_PARM_1+3
+        stx	*res3
+        ldx	__divulong_PARM_1+2
+        stx	*res2
+
+	lda     #0
+        sta     *rem+0
+        sta     *rem+1
+        sta     *rem+2
+        sta     *rem+3
+        ldy     #32
+L0:
+	asl     *res0
+        rol     *res1
+        rol     *res2
+        rol     *res3
+        rol     a
+        rol     *rem+1
+        rol     *rem+2
+        rol     *rem+3
+
+; Do a subtraction. we do not have enough space to store the intermediate
+; result, so we may have to do the subtraction twice.
+        tax
+        cmp     *den+0
+        lda     *rem+1
+        sbc     *den+1
+        lda     *rem+2
+        sbc     *den+2
+        lda     *rem+3
+        sbc     *den+3
+        bcc     L1
+
+; Overflow, do the subtraction again, this time store the result
+        sta     *rem+3	; We have the high byte already
+        txa
+        sbc     *den+0	; byte 0
+        tax
+        lda     *rem+1
+        sbc     *den+1
+        sta     *rem+1	; byte 1
+        lda     *rem+2
+        sbc     *den+2
+        sta     *rem+2 	; byte 2
+        inc     *res0	; Set result bit
+L1:
+	txa
+        dey
+        bne     L0
+        sta     *rem+0
+        rts
+

--- a/gbdk-lib/libc/asm/mos6502/_memcpy.s
+++ b/gbdk-lib/libc/asm/mos6502/_memcpy.s
@@ -1,0 +1,95 @@
+;-------------------------------------------------------------------------
+;   memcpy.s - standarc C library
+;
+;   Copyright (C) 2003, Ullrich von Bassewitz
+;   Copyright (C) 2009, Christian Krueger
+;   Copyright (C) 2022, Gabriele Gorla
+;
+;   This library is free software; you can redistribute it and/or modify it
+;   under the terms of the GNU General Public License as published by the
+;   Free Software Foundation; either version 2, or (at your option) any
+;   later version.
+;
+;   This library is distributed in the hope that it will be useful,
+;   but WITHOUT ANY WARRANTY; without even the implied warranty of
+;   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;   GNU General Public License for more details.
+;
+;   You should have received a copy of the GNU General Public License
+;   along with this library; see the file COPYING. If not, write to the
+;   Free Software Foundation, 51 Franklin Street, Fifth Floor, Boston,
+;   MA 02110-1301, USA.
+;
+;   As a special exception, if you link this library with other files,
+;   some of which are compiled with SDCC, to produce an executable,
+;   this library does not by itself cause the resulting executable to
+;   be covered by the GNU General Public License. This exception does
+;   not however invalidate any other reasons why the executable file
+;   might be covered by the GNU General Public License.
+;-------------------------------------------------------------------------
+
+	.module ___memcpy
+
+;--------------------------------------------------------
+; exported symbols
+;--------------------------------------------------------
+	.globl ___memcpy_PARM_2
+	.globl ___memcpy_PARM_3
+	.globl ___memcpy
+
+;--------------------------------------------------------
+; overlayable function paramters in zero page
+;--------------------------------------------------------
+	.area	OSEG    (PAG, OVR)
+___memcpy_PARM_2:
+	.ds 2
+___memcpy_PARM_3:
+	.ds 2
+
+;--------------------------------------------------------
+; local aliases
+;--------------------------------------------------------
+	.define save  "___SDCC_m6502_ret0"
+	.define dst   "___SDCC_m6502_ret2"
+	.define src   "___memcpy_PARM_2"
+	.define count "___memcpy_PARM_3"
+	
+;--------------------------------------------------------
+; code
+;--------------------------------------------------------
+	.area CODE
+
+___memcpy:
+	sta	*save+0
+	stx	*save+1
+	sta	*dst+0
+	stx	*dst+1
+
+	ldy	#0
+	ldx	*count+1
+	beq	L2
+L1:
+	lda	[*src],y
+	sta	[*dst],y
+	iny
+	lda	[*src],y
+	sta	[*dst],y
+	iny
+	bne	L1
+	inc	*src+1
+	inc	*dst+1
+	dex
+	bne	L1
+L2:
+	ldx	*count+0
+	beq	done
+L3:
+	lda	[*src],y
+	sta	[*dst],y
+	iny
+	dex
+	bne	L3
+done:
+	lda	*save+0
+	ldx	*save+1
+	rts

--- a/gbdk-lib/libc/asm/mos6502/_memmove.c
+++ b/gbdk-lib/libc/asm/mos6502/_memmove.c
@@ -1,7 +1,9 @@
 /*-------------------------------------------------------------------------
-   atomic_flag_clear.c
+   _memmove.c - part of string library functions
 
-   Philipp Klaus Krause, pkk@spth.de 2020
+   Copyright (C) 1999, Sandeep Dutta . sandeep.dutta@usa.net
+   Adapted By -  Erik Petrich  . epetrich@users.sourceforge.net
+   from _memcpy.c which was originally
 
    This library is free software; you can redistribute it and/or modify it
    under the terms of the GNU General Public License as published by the
@@ -25,17 +27,28 @@
    not however invalidate any other reasons why the executable file
    might be covered by the GNU General Public License.
 -------------------------------------------------------------------------*/
+#include <string.h>
+#include <stdint.h>
 
-#include <stdatomic.h>
-
-void atomic_flag_clear(volatile atomic_flag *object)
+void *memmove (void *dst, const void *src, size_t size)
 {
-#if defined(__SDCC_z80) || defined(__SDCC_z180) || defined(__SDCC_ez80_z80) || defined(__SDCC_sm83) || defined(__SDCC_r2k) || defined(__SDCC_r3ka) || defined(__SDCC_stm8) || defined(__SDCC_hc08) || defined(__SDCC_s08) || defined(__SDCC_mos6502)
-	object->flag = 1;
-#elif defined(__SDCC_mcs51)
-	object->flag = 0;
-#else
-#error Support for atomic_flag not implemented
-#endif
-}
+	size_t c = size;
+	if (c == 0)
+		return dst;
 
+	char *d = dst;
+	const char *s = src;
+	if (s < d) {
+		d += c;
+		s += c;
+		do {
+			*--d = *--s;
+		} while (--c);
+	} else {
+		do {
+			*d++ = *s++;
+		} while (--c);
+	}
+
+	return dst;
+}

--- a/gbdk-lib/libc/asm/mos6502/_memset.c
+++ b/gbdk-lib/libc/asm/mos6502/_memset.c
@@ -1,0 +1,329 @@
+/*-------------------------------------------------------------------------
+   _memset.c - part of string library functions
+
+   Copyright (C) 1999, Sandeep Dutta . sandeep.dutta@usa.net
+   Copyright (C) 2020, Sergey Belyashov sergey.belyashov@gmail.com
+   Copyright (C) 2022, Sebastian 'basxto' Riedel
+   mcs51 assembler by Frieder Ferlemann (2007)
+
+   This library is free software; you can redistribute it and/or modify it
+   under the terms of the GNU General Public License as published by the
+   Free Software Foundation; either version 2, or (at your option) any
+   later version.
+
+   This library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this library; see the file COPYING. If not, write to the
+   Free Software Foundation, 51 Franklin Street, Fifth Floor, Boston,
+   MA 02110-1301, USA.
+
+   As a special exception, if you link this library with other files,
+   some of which are compiled with SDCC, to produce an executable,
+   this library does not by itself cause the resulting executable to
+   be covered by the GNU General Public License. This exception does
+   not however invalidate any other reasons why the executable file
+   might be covered by the GNU General Public License.
+-------------------------------------------------------------------------*/
+
+#include <stdlib.h>
+#include <string.h>
+
+#undef memset /* Avoid conflict with builtin memset() in Z80 and some related ports */
+
+#if defined (_SDCC_NO_ASM_LIB_FUNCS) || !defined (__SDCC_mcs51) || \
+    (!defined (__SDCC_MODEL_SMALL) && !defined (__SDCC_MODEL_LARGE)) || \
+     (defined (__SDCC_STACK_AUTO) || defined (__SDCC_PARMS_IN_BANK1) )
+
+#ifdef __SDCC_BROKEN_STRING_FUNCTIONS
+void *memset (void *s, unsigned char c, size_t n)
+#else
+void *memset (void *s, int c, size_t n)
+#endif
+
+#if !defined (_SDCC_NO_ASM_LIB_FUNCS) && (\
+              defined (__SDCC_z80) ||\
+              defined (__SDCC_z180) ||\
+              defined (__SDCC_z80n))
+#ifdef __SDCC_BROKEN_STRING_FUNCTIONS      
+#error Unimplemented broken string function
+#endif    
+__naked
+{
+  (void)s;
+  (void)c;
+  (void)n;
+  __asm
+    pop   iy
+    pop   bc
+    push  hl
+    ld    a, c
+    or    a, b
+    jr    Z, end
+    ld    (hl), e
+    dec   bc
+    ld    a, c
+    or    a, b
+    jr    Z, end
+    ld    e, l
+    ld    d, h
+    inc   de
+    ldir 
+end:
+    pop   de
+    jp	(iy)
+  __endasm;
+}
+#elif !defined (_SDCC_NO_ASM_LIB_FUNCS) && (\
+              defined (__SDCC_ez80_z80) ||\
+              defined (__SDCC_r2k) ||\
+              defined (__SDCC_z3ka))
+
+__naked
+{
+  (void)s;
+  (void)c;
+  (void)n;
+  __asm
+    pop   af
+    pop   hl
+#ifdef __SDCC_BROKEN_STRING_FUNCTIONS
+    dec   sp
+#endif
+    pop   de
+    pop   bc
+    push  bc
+    push  de
+#ifdef __SDCC_BROKEN_STRING_FUNCTIONS
+    inc   sp
+#endif
+    push  hl
+    push  af
+    ld    a, c
+    or    a, b
+    ret   Z
+#ifdef __SDCC_BROKEN_STRING_FUNCTIONS
+    ld    (hl), d
+#else
+    ld    (hl), e
+#endif
+    dec   bc
+    ld    a, c
+    or    a, b
+    ret   Z
+    push  hl
+    ld    e, l
+    ld    d, h
+    inc   de
+    ldir
+    pop   hl
+    ret
+  __endasm;
+}
+#elif !defined (_SDCC_NO_ASM_LIB_FUNCS) && defined(__SDCC_sm83)
+__naked
+{
+	(void)s;//de
+	(void)c;//bc or for broken string function in a
+	(void)n;//stack+2, stack+3
+__asm
+        ; Algorithm is Duff`s device
+	ldhl	sp,	#3
+__endasm;
+#ifdef __SDCC_BROKEN_STRING_FUNCTIONS
+__asm
+	ld	b, (hl)
+	dec	hl
+__endasm;
+#else
+__asm
+
+	ld	a, (hl-)
+	ld	b, a
+	ld	a, c
+__endasm;
+#endif  
+__asm
+	ld	c, (hl)
+	ld	l, e
+	ld	h, d
+	;shift LSB to carry
+	srl	b
+	rr	c
+	jr nc, skip_one
+        ld	(hl+), a
+skip_one:
+	;n/2 in bc
+	;shift second LSB to carry
+	srl	b
+	rr	c
+        ;n/4 in bc
+	inc	b
+	inc	c
+	jr nc, test
+	jr	copy_two
+copy_four:
+        ld	(hl+), a
+	ld	(hl+), a
+copy_two:
+        ld	(hl+), a
+	ld	(hl+), a
+test:
+	dec	c
+	jr	NZ, copy_four
+	dec	b
+	jr	NZ, copy_four
+        ;restore dest
+	ld	c, e
+	ld	b, d
+	pop	hl
+	pop	af
+	jp	(hl)
+__endasm;
+}
+#else
+{
+  register size_t sz = n;
+  if (sz != 0)
+    {
+      register char *dst = s;
+      register char data = (char)c;
+      do {
+        *dst++ = data;
+      } while (--sz);
+    }
+  return s;
+}
+#endif
+#else
+
+  /* assembler implementation for mcs51 */
+  static void dummy(void) __naked
+  {
+    __asm
+
+  /* assigning function parameters to registers.
+     __SDCC_PARMS_IN_BANK1 or __SDCC_STACK_AUTO not yet implemented. */
+  #if defined (__SDCC_MODEL_SMALL)
+
+    #if defined(__SDCC_NOOVERLAY)
+        .area DSEG    (DATA)
+    #else
+        .area OSEG    (OVR,DATA)
+    #endif
+        _memset_PARM_2::
+              .ds 1
+        _memset_PARM_3::
+              .ds 2
+
+        .area CSEG    (CODE)
+
+        _memset::
+
+        ;   Assign buf (b holds memspace, no need to touch)
+                mov     r4,dpl
+                mov     r5,dph
+                ;
+        ;   Assign count
+                mov     r6,_memset_PARM_3
+                mov     r7,(_memset_PARM_3 + 1)
+                ;
+        ;   if (!count) return buf;
+        ;   check for count != 0 intermangled with gymnastic
+        ;   preparing djnz instructions
+                cjne    r6,#0x00,COUNT_LSB_NOT_ZERO
+                mov     a,r7
+                jz      MEMSET_END
+                dec     r7
+        COUNT_LSB_NOT_ZERO:
+                inc     r7
+                ;
+                ; This was 8 byte overhead for preparing
+                ; the count argument for an integer loop with two
+                ; djnz instructions - it might make sense to
+                ; let SDCC automatically generate this when
+                ; it encounters a loop like:
+                ; for(i=0;i<j;i++){...}
+                ; (at least for option --opt-code-speed)
+                ;
+
+        ;   Assign ch
+                mov     a,_memset_PARM_2
+
+  #else
+
+        .area XSEG    (XDATA)
+
+        _memset_PARM_2::
+                .ds 1
+        _memset_PARM_3::
+                .ds 2
+
+        .area CSEG    (CODE)
+
+        _memset::
+
+        ;   Assign buf (b holds memspace, no need to touch)
+                mov     r4,dpl
+                mov     r5,dph
+                ;
+        ;   Assign count
+                mov     dptr,#_memset_PARM_3
+                movx    a,@dptr
+                mov     r6,a
+                inc     dptr
+                movx    a,@dptr
+                mov     r7,a
+                ;
+        ;   if (!count) return buf;
+        ;   check for count != 0 intermangled with gymnastic
+        ;   preparing djnz instructions
+                cjne    r6,#0x00,COUNT_LSB_NOT_ZERO
+        ;   acc holds r7
+                jz      MEMSET_END
+                dec     r7
+        COUNT_LSB_NOT_ZERO:
+                inc     r7
+                ;
+        ;   Assign ch
+                mov     dptr,#_memset_PARM_2
+                movx    a,@dptr
+        ;   acc is precious now
+                ;
+        ;   Restore dptr
+                mov     dpl,r4
+                mov     dph,r5
+
+  #endif
+
+        /* now independent of the parameter passing everything
+           should be in registers by now and the loop may start */
+        ;   _memset.c do {
+
+        MEMSET_LOOP:
+        ;   _memset.c *p = ch;
+                lcall   __gptrput
+
+        ;   _memset.c p++;
+                inc     dptr
+
+        ;   _memset.c } while(--count) ;
+                djnz    r6,MEMSET_LOOP
+                djnz    r7,MEMSET_LOOP
+                ;
+
+        MEMSET_END:
+        ;   _memset.c return buf ;
+                ; b was unchanged
+                mov     dpl,r4
+                mov     dph,r5
+                ;
+                ret
+
+    __endasm;
+  }
+
+#endif

--- a/gbdk-lib/libc/asm/mos6502/_modsint.s
+++ b/gbdk-lib/libc/asm/mos6502/_modsint.s
@@ -1,0 +1,59 @@
+;-------------------------------------------------------------------------
+;   _modsint.s - routine for division of 16 bit signed int
+;
+;   Copyright (C) 1998, Ullrich von Bassewitz
+;   Copyright (C) 2022, Gabriele Gorla
+;
+;   This library is free software; you can redistribute it and/or modify it
+;   under the terms of the GNU General Public License as published by the
+;   Free Software Foundation; either version 2, or (at your option) any
+;   later version.
+;
+;   This library is distributed in the hope that it will be useful,
+;   but WITHOUT ANY WARRANTY; without even the implied warranty of
+;   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;   GNU General Public License for more details.
+;
+;   You should have received a copy of the GNU General Public License
+;   along with this library; see the file COPYING. If not, write to the
+;   Free Software Foundation, 51 Franklin Street, Fifth Floor, Boston,
+;   MA 02110-1301, USA.
+;
+;   As a special exception, if you link this library with other files,
+;   some of which are compiled with SDCC, to produce an executable,
+;   this library does not by itself cause the resulting executable to
+;   be covered by the GNU General Public License. This exception does
+;   not however invalidate any other reasons why the executable file
+;   might be covered by the GNU General Public License.
+;-------------------------------------------------------------------------
+
+	.module _modsint
+
+;--------------------------------------------------------
+; exported symbols
+;--------------------------------------------------------
+	.globl __modsint
+
+;--------------------------------------------------------
+; local aliases
+;--------------------------------------------------------
+	.define res "___SDCC_m6502_ret0"
+	.define den "__divsint_PARM_2"
+	.define rem "___SDCC_m6502_ret2"
+	.define s1  "___SDCC_m6502_ret4"
+	.define s2  "___SDCC_m6502_ret5"
+
+;--------------------------------------------------------
+; code
+;--------------------------------------------------------
+	.area CODE
+
+__modsint:
+	jsr 	___sdivmod16
+	lda	*rem+0
+	ldx	*rem+1
+	ldy	*s1
+	bpl	pos
+	jmp 	___negax
+pos:
+	rts

--- a/gbdk-lib/libc/asm/mos6502/_modslong.s
+++ b/gbdk-lib/libc/asm/mos6502/_modslong.s
@@ -1,0 +1,81 @@
+;-------------------------------------------------------------------------
+;   _modslong.s - routine for remainder for 32 bit signed long division
+;
+;   Copyright (C) 1998, Ullrich von Bassewitz
+;   Copyright (C) 2022, Gabriele Gorla
+;
+;   This library is free software; you can redistribute it and/or modify it
+;   under the terms of the GNU General Public License as published by the
+;   Free Software Foundation; either version 2, or (at your option) any
+;   later version.
+;
+;   This library is distributed in the hope that it will be useful,
+;   but WITHOUT ANY WARRANTY; without even the implied warranty of
+;   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;   GNU General Public License for more details.
+;
+;   You should have received a copy of the GNU General Public License
+;   along with this library; see the file COPYING. If not, write to the
+;   Free Software Foundation, 51 Franklin Street, Fifth Floor, Boston,
+;   MA 02110-1301, USA.
+;
+;   As a special exception, if you link this library with other files,
+;   some of which are compiled with SDCC, to produce an executable,
+;   this library does not by itself cause the resulting executable to
+;   be covered by the GNU General Public License. This exception does
+;   not however invalidate any other reasons why the executable file
+;   might be covered by the GNU General Public License.
+;-------------------------------------------------------------------------
+
+	.module _modslong
+
+;--------------------------------------------------------
+; exported symbols
+;--------------------------------------------------------
+	.globl __modslong
+
+;--------------------------------------------------------
+; local aliases
+;--------------------------------------------------------
+	.define res0 "__divslong_PARM_1+0"
+	.define res1 "__divslong_PARM_1+1"
+	.define res2 "___SDCC_m6502_ret2"
+	.define res3 "___SDCC_m6502_ret3"
+	.define den  "__divslong_PARM_2"
+	.define rem  "___SDCC_m6502_ret4"
+	.define s1   "___SDCC_m6502_ret0"
+	.define s2   "___SDCC_m6502_ret1"
+
+;--------------------------------------------------------
+; code
+;--------------------------------------------------------
+	.area CODE
+__modslong:
+	jsr	___sdivmod32
+	lda	*s1
+	bpl	pos
+; neg res
+	sec
+	lda	#0x00
+	sbc	*rem+0
+	tay
+	lda	#0x00
+	sbc	*rem+1
+	tax
+	lda	#0x00
+	sbc	*rem+2
+	sta	*res2
+	lda	#0x00
+	sbc	*rem+3
+	sta	*res3
+	tya
+	rts
+pos:
+	lda	*rem+3
+	sta	*res3
+	lda	*rem+2
+	sta	*res2
+	ldx	*rem+1
+	lda	*rem+0
+	rts
+

--- a/gbdk-lib/libc/asm/mos6502/_moduint.s
+++ b/gbdk-lib/libc/asm/mos6502/_moduint.s
@@ -1,0 +1,54 @@
+;-------------------------------------------------------------------------
+;   _moduint.s - routine for remainder of 16 bit unsigned division
+;
+;   Copyright (C) 2022, Gabriele Gorla
+;
+;   This library is free software; you can redistribute it and/or modify it
+;   under the terms of the GNU General Public License as published by the
+;   Free Software Foundation; either version 2, or (at your option) any
+;   later version.
+;
+;   This library is distributed in the hope that it will be useful,
+;   but WITHOUT ANY WARRANTY; without even the implied warranty of
+;   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;   GNU General Public License for more details.
+;
+;   You should have received a copy of the GNU General Public License
+;   along with this library; see the file COPYING. If not, write to the
+;   Free Software Foundation, 51 Franklin Street, Fifth Floor, Boston,
+;   MA 02110-1301, USA.
+;
+;   As a special exception, if you link this library with other files,
+;   some of which are compiled with SDCC, to produce an executable,
+;   this library does not by itself cause the resulting executable to
+;   be covered by the GNU General Public License. This exception does
+;   not however invalidate any other reasons why the executable file
+;   might be covered by the GNU General Public License.
+;-------------------------------------------------------------------------
+
+	.module _moduint
+
+;--------------------------------------------------------
+; exported symbols
+;--------------------------------------------------------
+	.globl __moduint
+	
+;--------------------------------------------------------
+; local aliases
+;--------------------------------------------------------
+	.define res "___SDCC_m6502_ret0"
+	.define div "__moduint_PARM_2"
+	.define rem "___SDCC_m6502_ret2"
+	.define s1  "___SDCC_m6502_ret4"
+	.define s2  "___SDCC_m6502_ret5"
+
+;--------------------------------------------------------
+; code
+;--------------------------------------------------------
+	.area CODE
+	
+__moduint:
+	jsr 	___udivmod16
+	lda	*rem+0
+	ldx	*rem+1
+	rts	

--- a/gbdk-lib/libc/asm/mos6502/_modulong.s
+++ b/gbdk-lib/libc/asm/mos6502/_modulong.s
@@ -1,0 +1,61 @@
+;-------------------------------------------------------------------------
+;   _modulong.s - routine for remainder of 32 bit unsigned long division
+;
+;   Copyright (C) 2022, Gabriele Gorla
+;
+;   This library is free software; you can redistribute it and/or modify it
+;   under the terms of the GNU General Public License as published by the
+;   Free Software Foundation; either version 2, or (at your option) any
+;   later version.
+;
+;   This library is distributed in the hope that it will be useful,
+;   but WITHOUT ANY WARRANTY; without even the implied warranty of
+;   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;   GNU General Public License for more details.
+;
+;   You should have received a copy of the GNU General Public License
+;   along with this library; see the file COPYING. If not, write to the
+;   Free Software Foundation, 51 Franklin Street, Fifth Floor, Boston,
+;   MA 02110-1301, USA.
+;
+;   As a special exception, if you link this library with other files,
+;   some of which are compiled with SDCC, to produce an executable,
+;   this library does not by itself cause the resulting executable to
+;   be covered by the GNU General Public License. This exception does
+;   not however invalidate any other reasons why the executable file
+;   might be covered by the GNU General Public License.
+;-------------------------------------------------------------------------
+
+	.module _modulong
+	
+;--------------------------------------------------------
+; exported symbols
+;--------------------------------------------------------
+	.globl __modulong
+	
+;--------------------------------------------------------
+; local aliases
+;--------------------------------------------------------
+	.define res0 "__modulong_PARM_1+0"
+	.define res1 "__modulong_PARM_1+1"
+	.define res2 "___SDCC_m6502_ret2"
+	.define res3 "___SDCC_m6502_ret3"
+	.define den  "__modulong_PARM_2"
+	.define rem  "___SDCC_m6502_ret4"
+	.define s1   "___SDCC_m6502_ret0"
+	.define s2   "___SDCC_m6502_ret1"
+	
+;--------------------------------------------------------
+; code
+;--------------------------------------------------------
+	.area CODE
+
+__modulong:
+	jsr 	___udivmod32
+	lda 	*rem+3
+	sta	*res3
+	lda	*rem+2
+	sta	*res2
+	ldx	*rem+1
+	lda	*rem+0
+	rts

--- a/gbdk-lib/libc/asm/mos6502/_mulint.s
+++ b/gbdk-lib/libc/asm/mos6502/_mulint.s
@@ -1,0 +1,82 @@
+;-------------------------------------------------------------------------
+;   _mulint.s - routine for multiplication of 16 bit (unsigned) int
+;
+;   Copyright (C) 2009, Ullrich von Bassewitz
+;   Copyright (C) 2022, Gabriele Gorla
+;
+;   This library is free software; you can redistribute it and/or modify it
+;   under the terms of the GNU General Public License as published by the
+;   Free Software Foundation; either version 2, or (at your option) any
+;   later version.
+;
+;   This library is distributed in the hope that it will be useful,
+;   but WITHOUT ANY WARRANTY; without even the implied warranty of
+;   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;   GNU General Public License for more details.
+;
+;   You should have received a copy of the GNU General Public License
+;   along with this library; see the file COPYING. If not, write to the
+;   Free Software Foundation, 51 Franklin Street, Fifth Floor, Boston,
+;   MA 02110-1301, USA.
+;
+;   As a special exception, if you link this library with other files,
+;   some of which are compiled with SDCC, to produce an executable,
+;   this library does not by itself cause the resulting executable to
+;   be covered by the GNU General Public License. This exception does
+;   not however invalidate any other reasons why the executable file
+;   might be covered by the GNU General Public License.
+;-------------------------------------------------------------------------
+
+	.module _mulint
+
+;--------------------------------------------------------
+; exported symbols
+;--------------------------------------------------------
+	.globl __mulint_PARM_2
+	.globl __mulint
+
+;--------------------------------------------------------
+; overlayable function paramters in zero page
+;--------------------------------------------------------
+	.area	OSEG    (PAG, OVR)
+__mulint_PARM_2:
+	.ds 2
+
+;--------------------------------------------------------
+; local aliases
+;--------------------------------------------------------
+	.define tmp "___SDCC_m6502_ret2"
+
+;--------------------------------------------------------
+; code
+;--------------------------------------------------------
+	.area CODE
+
+__mulint:
+	sta	*___SDCC_m6502_ret0
+	stx	*___SDCC_m6502_ret1
+	lda	#0
+	sta	*tmp
+	ldy	#16
+	lsr	*___SDCC_m6502_ret1
+	ror	*___SDCC_m6502_ret0
+next_bit:
+	bcc	skip
+	clc
+	adc	*__mulint_PARM_2+0
+	tax
+	lda	*__mulint_PARM_2+1
+	adc	*tmp
+	sta	*tmp
+	txa
+skip:
+	ror	*tmp
+	ror	a
+	ror	*___SDCC_m6502_ret1
+	ror	*___SDCC_m6502_ret0
+	dey
+	bne	next_bit
+
+	lda	*___SDCC_m6502_ret0
+	ldx	*___SDCC_m6502_ret1
+	rts

--- a/gbdk-lib/libc/asm/mos6502/_mullong.s
+++ b/gbdk-lib/libc/asm/mos6502/_mullong.s
@@ -1,0 +1,107 @@
+;-------------------------------------------------------------------------
+;   _mullong.s - routine for multiplication of 32 bit (unsigned) long
+;
+;   Copyright (C) 1998, Ullrich von Bassewitz
+;   Copyright (C) 2022, Gabriele Gorla
+;
+;   This library is free software; you can redistribute it and/or modify it
+;   under the terms of the GNU General Public License as published by the
+;   Free Software Foundation; either version 2, or (at your option) any
+;   later version.
+;
+;   This library is distributed in the hope that it will be useful,
+;   but WITHOUT ANY WARRANTY; without even the implied warranty of
+;   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;   GNU General Public License for more details.
+;
+;   You should have received a copy of the GNU General Public License
+;   along with this library; see the file COPYING. If not, write to the
+;   Free Software Foundation, 51 Franklin Street, Fifth Floor, Boston,
+;   MA 02110-1301, USA.
+;
+;   As a special exception, if you link this library with other files,
+;   some of which are compiled with SDCC, to produce an executable,
+;   this library does not by itself cause the resulting executable to
+;   be covered by the GNU General Public License. This exception does
+;   not however invalidate any other reasons why the executable file
+;   might be covered by the GNU General Public License.
+;-------------------------------------------------------------------------
+
+	.module _mullong
+
+;--------------------------------------------------------
+; exported symbols
+;--------------------------------------------------------
+	.globl __mullong_PARM_2
+	.globl __mullong_PARM_1
+	.globl __mullong
+
+;--------------------------------------------------------
+; overlayable function paramters in zero page
+;--------------------------------------------------------
+	.area	OSEG    (PAG, OVR)
+__mullong_PARM_1:
+	.ds 4
+__mullong_PARM_2:
+	.ds 4
+
+;--------------------------------------------------------
+; local aliases
+;--------------------------------------------------------
+	.define tmp  "___SDCC_m6502_ret4"
+	.define res0 "__mullong_PARM_1+0"
+	.define res1 "__mullong_PARM_1+1"
+	.define res2 "___SDCC_m6502_ret2"
+	.define res3 "___SDCC_m6502_ret3"
+
+;--------------------------------------------------------
+; code
+;--------------------------------------------------------
+	.area CODE
+
+__mullong:
+
+        ldx	*__mullong_PARM_1+3
+        stx	*res3
+        ldx	*__mullong_PARM_1+2
+        stx	*res2
+;        ldx	*__mullong_PARM_1+1
+;        stx	*res1
+;        ldx	*__mullong_PARM_1+0
+;        stx	*res0
+
+        lda     #0
+        sta     *tmp+2
+        sta     *tmp+1
+        sta     *tmp+0
+
+        ldy     #32
+next_bit:
+	lsr     *tmp+2
+        ror     *tmp+1
+        ror     *tmp+0
+        ror     a
+        ror     *res3
+        ror     *res2
+        ror     *res1
+        ror     *res0
+        bcc     skip
+        clc
+        adc     *__mullong_PARM_2+0
+        tax
+        lda     *__mullong_PARM_2+1
+        adc     *tmp+0
+        sta     *tmp+0
+        lda     *__mullong_PARM_2+2
+        adc     *tmp+1
+        sta     *tmp+1
+        lda     *__mullong_PARM_2+3
+        adc     *tmp+2
+        sta     *tmp+2
+        txa
+skip:
+        dey
+        bpl	next_bit
+        ldx	*res1
+        lda	*res0
+	rts

--- a/gbdk-lib/libc/asm/mos6502/_mulschar.s
+++ b/gbdk-lib/libc/asm/mos6502/_mulschar.s
@@ -1,0 +1,104 @@
+;-------------------------------------------------------------------------
+;   _mulschar.s - routine for multiplication of 16 bit (unsigned) int
+;
+;   Copyright (C) 2009, Ullrich von Bassewitz
+;   Copyright (C) 2022, Gabriele Gorla
+;
+;   This library is free software; you can redistribute it and/or modify it
+;   under the terms of the GNU General Public License as published by the
+;   Free Software Foundation; either version 2, or (at your option) any
+;   later version.
+;
+;   This library is distributed in the hope that it will be useful,
+;   but WITHOUT ANY WARRANTY; without even the implied warranty of
+;   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;   GNU General Public License for more details.
+;
+;   You should have received a copy of the GNU General Public License
+;   along with this library; see the file COPYING. If not, write to the
+;   Free Software Foundation, 51 Franklin Street, Fifth Floor, Boston,
+;   MA 02110-1301, USA.
+;
+;   As a special exception, if you link this library with other files,
+;   some of which are compiled with SDCC, to produce an executable,
+;   this library does not by itself cause the resulting executable to
+;   be covered by the GNU General Public License. This exception does
+;   not however invalidate any other reasons why the executable file
+;   might be covered by the GNU General Public License.
+;-------------------------------------------------------------------------
+
+	.module _mulschar
+
+;--------------------------------------------------------
+; exported symbols
+;--------------------------------------------------------
+	.globl __mulschar
+	.globl __muluschar
+	.globl __mulsuchar
+
+;--------------------------------------------------------
+; overlayable function paramters in zero page
+;--------------------------------------------------------
+	.area	OSEG    (PAG, OVR)
+
+;--------------------------------------------------------
+; local aliases
+;--------------------------------------------------------
+	.define arg1 "___SDCC_m6502_ret0"
+	.define arg2 "___SDCC_m6502_ret2"
+	.define s1 "___SDCC_m6502_ret4"
+	.define s2 "___SDCC_m6502_ret5"
+
+;--------------------------------------------------------
+; code
+;--------------------------------------------------------
+	.area CODE
+
+__mulschar:
+	sta	s1
+	cmp	#0x00
+	bpl 	pos1
+	sec
+	eor	#0xff
+	adc	#0x00
+pos1:	
+	sta     arg1
+	txa
+	sta	s2
+	bpl 	pos2
+	sec
+	eor	#0xff
+	adc	#0x00
+pos2:	
+	sta     arg2
+	
+	jsr 	___umul8
+	lda	s1
+	eor	s2
+	bpl	skip
+	lda	arg2
+	jmp	___negax
+
+skip:	lda 	arg2
+	rts
+
+__muluschar:
+	stx	__mulint_PARM_2
+	ldx	#0x00
+	stx	__mulint_PARM_2+1
+	cmp	#0x00
+	bpl	pos1m
+	ldx 	#0xff
+pos1m:
+	jmp	__mulint
+	
+__mulsuchar:
+	sta	__mulint_PARM_2
+	txa
+	ldx	#0x00
+	stx	__mulint_PARM_2+1
+	cmp	#0x00
+	bpl	pos2m
+	ldx 	#0xff
+pos2m:
+	jmp	__mulint

--- a/gbdk-lib/libc/asm/mos6502/_muluchar.s
+++ b/gbdk-lib/libc/asm/mos6502/_muluchar.s
@@ -1,0 +1,71 @@
+;-------------------------------------------------------------------------
+;   _muluchar.s - routine for multiplication of 16 bit (unsigned) int
+;
+;   Copyright (C) 2009, Ullrich von Bassewitz
+;   Copyright (C) 2022, Gabriele Gorla
+;
+;   This library is free software; you can redistribute it and/or modify it
+;   under the terms of the GNU General Public License as published by the
+;   Free Software Foundation; either version 2, or (at your option) any
+;   later version.
+;
+;   This library is distributed in the hope that it will be useful,
+;   but WITHOUT ANY WARRANTY; without even the implied warranty of
+;   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;   GNU General Public License for more details.
+;
+;   You should have received a copy of the GNU General Public License
+;   along with this library; see the file COPYING. If not, write to the
+;   Free Software Foundation, 51 Franklin Street, Fifth Floor, Boston,
+;   MA 02110-1301, USA.
+;
+;   As a special exception, if you link this library with other files,
+;   some of which are compiled with SDCC, to produce an executable,
+;   this library does not by itself cause the resulting executable to
+;   be covered by the GNU General Public License. This exception does
+;   not however invalidate any other reasons why the executable file
+;   might be covered by the GNU General Public License.
+;-------------------------------------------------------------------------
+
+	.module _muluchar
+
+;--------------------------------------------------------
+; exported symbols
+;--------------------------------------------------------
+	.globl __muluchar
+	.globl ___umul8
+	
+;--------------------------------------------------------
+; overlayable function paramters in zero page
+;--------------------------------------------------------
+	.area	OSEG    (PAG, OVR)
+
+;--------------------------------------------------------
+; local aliases
+;--------------------------------------------------------
+	.define arg1 "___SDCC_m6502_ret0"
+	.define arg2 "___SDCC_m6502_ret2"
+
+;--------------------------------------------------------
+; code
+;--------------------------------------------------------
+	.area CODE
+
+__muluchar:
+	sta     arg1
+	stx	arg2
+___umul8:
+        lda     #0              ; Clear byte 1
+        ldy     #8              ; Number of bits
+        lsr     arg2            ; Get first bit of RHS into carry
+L0:    	bcc	L1
+        clc
+        adc     arg1
+L1:    	ror
+        ror     arg2
+        dey
+        bne    	L0
+        tax
+;//        stx     arg2+1          ; Result in .XA and ptr1
+        lda     arg2            ; Load the result
+        rts                     ; Done

--- a/gbdk-lib/libc/asm/mos6502/_ret.c
+++ b/gbdk-lib/libc/asm/mos6502/_ret.c
@@ -1,7 +1,9 @@
 /*-------------------------------------------------------------------------
-   atomic_flag_clear.c
+   _ret.c
 
-   Philipp Klaus Krause, pkk@spth.de 2020
+   Copyright (C) 2003, Erik Petrich
+   Copyright (C) 2012, Philipp Klaus Krause
+   Considering how short this file is, it is probably not copyrightable, though.
 
    This library is free software; you can redistribute it and/or modify it
    under the terms of the GNU General Public License as published by the
@@ -10,10 +12,10 @@
 
    This library is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
    GNU General Public License for more details.
 
-   You should have received a copy of the GNU General Public License
+   You should have received a copy of the GNU General Public License 
    along with this library; see the file COPYING. If not, write to the
    Free Software Foundation, 51 Franklin Street, Fifth Floor, Boston,
    MA 02110-1301, USA.
@@ -26,16 +28,12 @@
    might be covered by the GNU General Public License.
 -------------------------------------------------------------------------*/
 
-#include <stdatomic.h>
-
-void atomic_flag_clear(volatile atomic_flag *object)
-{
-#if defined(__SDCC_z80) || defined(__SDCC_z180) || defined(__SDCC_ez80_z80) || defined(__SDCC_sm83) || defined(__SDCC_r2k) || defined(__SDCC_r3ka) || defined(__SDCC_stm8) || defined(__SDCC_hc08) || defined(__SDCC_s08) || defined(__SDCC_mos6502)
-	object->flag = 1;
-#elif defined(__SDCC_mcs51)
-	object->flag = 0;
-#else
-#error Support for atomic_flag not implemented
-#endif
-}
+__data unsigned char __SDCC_m6502_ret0;
+__data unsigned char __SDCC_m6502_ret1;
+__data unsigned char __SDCC_m6502_ret2;
+__data unsigned char __SDCC_m6502_ret3;
+__data unsigned char __SDCC_m6502_ret4;
+__data unsigned char __SDCC_m6502_ret5;
+__data unsigned char __SDCC_m6502_ret6;
+__data unsigned char __SDCC_m6502_ret7;
 

--- a/gbdk-lib/libc/asm/mos6502/_rrslonglong.c
+++ b/gbdk-lib/libc/asm/mos6502/_rrslonglong.c
@@ -1,0 +1,40 @@
+
+#pragma std_c99
+
+#include <stdint.h>
+
+#ifdef __SDCC_LONGLONG
+
+long long _rrslonglong(long long l, char s)
+{
+
+  uint8_t *const b = (uint8_t *)(&l);
+  unsigned char shift,t1,t2, sign;
+  signed char zb,i;
+
+  sign=b[7]&0x80;
+  
+  zb=s>>3;
+  if(zb) {
+    i=0;
+    for(;i<(8-zb);i++) {
+      b[i]=b[zb+i];
+    }
+    for(;i<8;i++)
+      b[i]=sign?0xff:0x00;
+  }
+  
+  shift=s&0x7;
+  while(shift--) {
+    t2=sign;
+    for(i=7-zb;i>=0;i--) {
+      t1=b[i]&1;
+      b[i]=(b[i]>>1)|t2;
+      t2=t1?0x80:0;
+    } 
+  }
+  
+  return(l);
+}
+
+#endif

--- a/gbdk-lib/libc/asm/mos6502/_rrulonglong.c
+++ b/gbdk-lib/libc/asm/mos6502/_rrulonglong.c
@@ -1,0 +1,38 @@
+
+#pragma std_c99
+
+#include <stdint.h>
+
+#ifdef __SDCC_LONGLONG
+
+unsigned long long _rrulonglong(unsigned long long l, char s)
+{
+
+  uint8_t *const b = (uint8_t *)(&l);
+  unsigned char shift,t1,t2;
+  signed char zb,i;
+  
+  zb=s>>3;
+  if(zb) {
+    for(i=0;i<(8-zb);i++) {
+      b[i]=b[zb+i];
+    }
+  
+    for(;i<8;i++)
+      b[i]=0;
+  }
+  
+  shift=s&0x7;
+  while(shift--) {
+    t2=0;
+    for(i=7-zb;i>=0;i--) {
+      t1=b[i]&1;
+      b[i]=(b[i]>>1)|t2;
+      t2=t1?0x80:0;
+    } 
+  }
+  
+  return(l);
+}
+
+#endif

--- a/gbdk-lib/libc/asm/mos6502/_strcmp.s
+++ b/gbdk-lib/libc/asm/mos6502/_strcmp.s
@@ -1,0 +1,80 @@
+;-------------------------------------------------------------------------
+;   _strcmp.s - standard C library function
+;
+;   Copyright (C) 1998, Ullrich von Bassewitz
+;   Copyright (C) 2022, Gabriele Gorla
+;
+;   This library is free software; you can redistribute it and/or modify it
+;   under the terms of the GNU General Public License as published by the
+;   Free Software Foundation; either version 2, or (at your option) any
+;   later version.
+;
+;   This library is distributed in the hope that it will be useful,
+;   but WITHOUT ANY WARRANTY; without even the implied warranty of
+;   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;   GNU General Public License for more details.
+;
+;   You should have received a copy of the GNU General Public License
+;   along with this library; see the file COPYING. If not, write to the
+;   Free Software Foundation, 51 Franklin Street, Fifth Floor, Boston,
+;   MA 02110-1301, USA.
+;
+;   As a special exception, if you link this library with other files,
+;   some of which are compiled with SDCC, to produce an executable,
+;   this library does not by itself cause the resulting executable to
+;   be covered by the GNU General Public License. This exception does
+;   not however invalidate any other reasons why the executable file
+;   might be covered by the GNU General Public License.
+;-------------------------------------------------------------------------
+
+	.module _strcmp
+
+;--------------------------------------------------------
+; exported symbols
+;--------------------------------------------------------
+	.globl _strcmp_PARM_2
+	.globl _strcmp
+
+;--------------------------------------------------------
+; overlayable function paramters in zero page
+;--------------------------------------------------------
+	.area	OSEG    (PAG, OVR)
+_strcmp_PARM_2:
+	.ds 2
+
+;--------------------------------------------------------
+; local aliases
+;--------------------------------------------------------
+	.define _str2 "_strcmp_PARM_2"
+	.define _str1 "___SDCC_m6502_ret0"
+;--------------------------------------------------------
+; code
+;--------------------------------------------------------
+	.area CODE
+
+_strcmp:
+	sta	*_str1+0
+	stx	*_str1+1
+
+	ldy	#0
+loop:
+	lda	[*_str1],y
+	cmp	[*_str2],y
+	bne	L1
+	tax
+	beq	end
+	iny
+	bne	loop
+	inc	*_str1+1
+	inc	*_str2+1
+	bne	loop
+L1:
+	bcs	L2
+	ldx	#0xFF
+;//	txa
+	rts
+L2:
+	ldx	#0x01
+;//	txa
+end:
+	rts

--- a/gbdk-lib/libc/asm/mos6502/_strcpy.s
+++ b/gbdk-lib/libc/asm/mos6502/_strcpy.s
@@ -1,0 +1,77 @@
+;-------------------------------------------------------------------------
+;   _strcpy.s - standard C library function
+;
+;   Copyright (C) 1998, Ullrich von Bassewitz
+;   Copyright (C) 2022, Gabriele Gorla
+;
+;   This library is free software; you can redistribute it and/or modify it
+;   under the terms of the GNU General Public License as published by the
+;   Free Software Foundation; either version 2, or (at your option) any
+;   later version.
+;
+;   This library is distributed in the hope that it will be useful,
+;   but WITHOUT ANY WARRANTY; without even the implied warranty of
+;   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;   GNU General Public License for more details.
+;
+;   You should have received a copy of the GNU General Public License
+;   along with this library; see the file COPYING. If not, write to the
+;   Free Software Foundation, 51 Franklin Street, Fifth Floor, Boston,
+;   MA 02110-1301, USA.
+;
+;   As a special exception, if you link this library with other files,
+;   some of which are compiled with SDCC, to produce an executable,
+;   this library does not by itself cause the resulting executable to
+;   be covered by the GNU General Public License. This exception does
+;   not however invalidate any other reasons why the executable file
+;   might be covered by the GNU General Public License.
+;-------------------------------------------------------------------------
+
+	.module _strcpy
+
+;--------------------------------------------------------
+; exported symbols
+;--------------------------------------------------------
+	.globl _strcpy_PARM_2
+	.globl _strcpy
+
+;--------------------------------------------------------
+; overlayable function paramters in zero page
+;--------------------------------------------------------
+	.area	OSEG    (PAG, OVR)
+_strcpy_PARM_2:
+	.ds 2
+
+;--------------------------------------------------------
+; local aliases
+;--------------------------------------------------------
+	.define _src "_strcpy_PARM_2"
+	.define _dst "___SDCC_m6502_ret0"
+	
+;--------------------------------------------------------
+; code
+;--------------------------------------------------------
+	.area CODE
+
+_strcpy:
+	sta	*_dst+0
+	stx	*_dst+1
+;//	lda	_strcpy_PARM_2+0
+;//	sta	*_src+0
+;//	ldx	_strcpy_PARM_2+1
+;//	stx	*_src+1
+
+	ldy	#0
+cpy_loop:
+	lda	[*_src],y
+	sta	[*_dst],y
+	beq	end
+	iny
+	bne	cpy_loop
+	inc	*_src+1
+	inc	*_dst+1
+	bne	cpy_loop
+;	jmp	cpy_loop
+end:
+	lda	*_dst+0
+	rts

--- a/gbdk-lib/libc/asm/mos6502/abs.c
+++ b/gbdk-lib/libc/asm/mos6502/abs.c
@@ -1,0 +1,20 @@
+
+int abs(int j) __naked
+{
+  (void)j;
+  __asm__("cpx #0x00");
+  __asm__("bpl skip");
+  __asm__("___negax::");
+  __asm__("sec");
+  __asm__("eor #0xff");
+  __asm__("adc #0x00");
+  __asm__("pha");
+  __asm__("txa");
+  __asm__("eor #0xff");
+  __asm__("adc #0x00");
+  __asm__("tax");
+  __asm__("pla");
+  __asm__("skip:");
+  __asm__("rts");
+  //	return (j < 0) ? -j : j;
+}

--- a/gbdk-lib/libc/asm/mos6502/atomic_flag_test_and_set.c
+++ b/gbdk-lib/libc/asm/mos6502/atomic_flag_test_and_set.c
@@ -1,0 +1,37 @@
+/*
+;  atomic_flag_test_and_set.s
+;
+;  Copyright (C) 2021, Gabriele Gorla
+;
+;  This library is free software; you can redistribute it and/or modify it
+;  under the terms of the GNU General Public License as published by the
+;  Free Software Foundation; either version 2, or (at your option) any
+;  later version.
+;
+;  This library is distributed in the hope that it will be useful,
+;  but WITHOUT ANY WARRANTY; without even the implied warranty of
+;  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+;  GNU General Public License for more details.
+;
+;  You should have received a copy of the GNU General Public License
+;  along with this library; see the file COPYING. If not, write to the
+;  Free Software Foundation, 51 Franklin Street, Fifth Floor, Boston,
+;   MA 02110-1301, USA.
+;
+;  As a special exception, if you link this library with other files,
+;  some of which are compiled with SDCC, to produce an executable,
+;  this library does not by itself cause the resulting executable to
+;  be covered by the GNU General Public License. This exception does
+;  not however invalidate any other reasons why the executable file
+;   might be covered by the GNU General Public License.
+*/
+
+#include <stdatomic.h>
+
+_Bool atomic_flag_test_and_set(volatile atomic_flag *object)
+{
+  unsigned char t;
+  t=object->flag;
+  object->flag=0;
+  return t^0x01;
+}

--- a/gbdk-lib/libc/sprintf.c
+++ b/gbdk-lib/libc/sprintf.c
@@ -4,7 +4,7 @@
 #include <stdlib.h>
 #include <stdint.h>
 
-typedef void (*emitter_t)(char, char **) OLDCALL;
+typedef void (*emitter_t)(char, char **) OLDCALL REENTRANT;
 
 static const char _hex[] = "0123456789ABCDEF";
 
@@ -98,7 +98,7 @@ void __printf(const char *format, emitter_t emitter, char **pData, va_list va)
     }
 }
 
-static void _sprintf_emitter(char c, char ** pData) OLDCALL {
+static void _sprintf_emitter(char c, char ** pData) OLDCALL REENTRANT {
     **pData = c;
     (*pData)++;
 }


### PR DESCRIPTION
* Add assembly support routines from sdcc-svn/sdcc/device/lib/mos6502/ to gbdk-lib/libc/asm/mos6502/
* Add gbdk-lib/libc/asm/mos6502/Makefile, based on corresponding sm83 / z80 Makefiles
* Add CPU-specific include files to gbdk-lib/include/asm/mos6502/, based on corresponding sm83 / z80 include files
* Update gbdk-lib/include/asm/sm83/types.h and gbdk-lib/include/asm/z80.types.h to define REENTRANT as no-op
* Update gbdk-lib/include/stdio.h to use REENTRANT keyword for printf and sprintf
* Update gbdk-lib/include/stdlib.h to prevent #if-clause from redefining __reentrant as a no-op
* Update gbdk-lib/include/stdatomic.h to consider mos6502 in #if-clause
* Update gbdk-lib/libc/_divulong.c to consider mos6502 in #if-clause
* Add mos6502 to PORTS in Makefile, gbdk-lib/Makefile.common and gbdk-lib/libc/Makefile
* Update Makefile to include sdas6500 and sdld in sdcc-install rule