### PR TITLE
CI/CD: Get Examples to build under windows

### DIFF
--- a/.github/workflows/gbdk_build_examples.yml
+++ b/.github/workflows/gbdk_build_examples.yml
@@ -151,15 +151,13 @@ jobs:
         if: (matrix.name == 'Windows-x64') || (matrix.name == 'Windows-x32')
         shell: cmd
         run: |
-          dir
-          # Now build the examples for all platforms
-          cd gbdk-2020          
+          # For Windows build Examples is a separate stage due to commands getting skipped(?) after calling msys make
+          # Now build the examples
+          cd gbdk-2020
           cd build
           cd gbdk
           cd examples
-          dir
           msys2 -c 'make'
-          dir
           cd ..
           cd ..
           cd ..

--- a/.github/workflows/gbdk_build_examples.yml
+++ b/.github/workflows/gbdk_build_examples.yml
@@ -145,11 +145,14 @@ jobs:
           set SDCCDIR=%CD%\sdcc
           cd gbdk-2020
           msys2 -c 'make'
+          dir
           # Now build the examples for all platforms
           cd build
           cd gbdk
           cd examples
+          dir
           msys2 -c 'make'
+          dir
           cd ..
           cd ..
           cd ..

--- a/.github/workflows/gbdk_build_examples.yml
+++ b/.github/workflows/gbdk_build_examples.yml
@@ -145,8 +145,15 @@ jobs:
           set SDCCDIR=%CD%\sdcc
           cd gbdk-2020
           msys2 -c 'make'
+          cd ..
+
+      - name: Build Examples GBDK-2020 Windows
+        if: (matrix.name == 'Windows-x64') || (matrix.name == 'Windows-x32')
+        shell: cmd
+        run: |
           dir
           # Now build the examples for all platforms
+          cd gbdk-2020          
           cd build
           cd gbdk
           cd examples
@@ -169,6 +176,7 @@ jobs:
           tar czf ../package/${{ env.BUILD_PACKAGE_FILENAME }} gbdk/examples
           cd ..
           cd ..
+
       - name: Package build Windows
         if: (matrix.name == 'Windows-x64') || (matrix.name == 'Windows-x32')
         shell: cmd
@@ -179,6 +187,7 @@ jobs:
           7z a ../package/${{ env.BUILD_PACKAGE_FILENAME }} gbdk/examples
           cd ..
           cd ..
+
       - name: Store build
         if: (matrix.name == 'Linux-64') || (matrix.name == 'MacOS-64') || ('Windows-x64') || ('Windows-x32')
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
- Splitting the example building out to a separate build stage resolves the issue. Just did that on a hunch that there might be some execution/cmd shell issue after msys make was invoked. Not sure what the core problem is.

PS. Prob should have done a rebase to squash the testing into a single working commit. No worries if you prefer to just copy in the change and cancel the PR ;D